### PR TITLE
Fixed packet checksum calculation

### DIFF
--- a/src/udpcp/protocol/packet.py
+++ b/src/udpcp/protocol/packet.py
@@ -336,4 +336,4 @@ class Packet:
         if self.checksum_mode is ChecksumMode.Disabled:
             return
 
-        self._checksum = zlib.adler32(self.as_bytes, 0)
+        self._checksum = zlib.adler32(self.as_bytes, 1)

--- a/tests/ut/test_packet.py
+++ b/tests/ut/test_packet.py
@@ -84,7 +84,7 @@ def test_checksum_mode_enabled():
         checksum_mode=ChecksumMode.Enabled,
     )
 
-    assert packet.checksum == 0x2960053
+    assert packet.checksum == 0x2A20054
 
 
 def test_checksum_mode_disabled():


### PR DESCRIPTION
The UDPCP documentation does not mention anything about starting
value for packet checksum calculation required by Alder32 algorithm
therefore the default value (equal to 1) should be used.

To avoid any changes in behaviour of checksum calculation by Alder32
and also make things obvious, we explicitly state the starting value.