### PR TITLE
Early implementation of UDPCP Socket

### DIFF
--- a/src/udpcp/__init__.py
+++ b/src/udpcp/__init__.py
@@ -1,3 +1,9 @@
 __all__ = [
+    'Socket',
     'protocol',
+    'exceptions',
 ]
+
+from .socket import Socket
+from . import protocol
+from . import exceptions

--- a/src/udpcp/exceptions.py
+++ b/src/udpcp/exceptions.py
@@ -1,0 +1,24 @@
+__all__ = [
+    'SocketError',
+    'SocketClosedError',
+    'SocketAckError',
+    'SocketPacketError',
+]
+
+import socket as native_socket
+
+
+class SocketError(native_socket.error):
+    pass
+
+
+class SocketClosedError(SocketError):
+    pass
+
+
+class SocketAckError(SocketError):
+    pass
+
+
+class SocketPacketError(SocketError):
+    pass

--- a/src/udpcp/protocol/__init__.py
+++ b/src/udpcp/protocol/__init__.py
@@ -1,11 +1,15 @@
 __all__ = [
     'Packet',
+    'PacketType',
     'MessageType',
     'TransferMode',
     'ChecksumMode',
+    'exceptions',
 ]
 
 from .packet import Packet
+from .packet_type import PacketType
 from .message_type import MessageType
 from .transfer_mode import TransferMode
 from .checksum_mode import ChecksumMode
+from . import exceptions

--- a/src/udpcp/protocol/_specification.py
+++ b/src/udpcp/protocol/_specification.py
@@ -3,11 +3,14 @@ __all__ = [
     'as_bytes',
 ]
 
-import typing
 import bitarray
 import itertools
 
-RawPacket = typing.NamedTuple('packet', (
+from typing import Any, Dict, NamedTuple, Generator, Iterable
+
+from . import exceptions
+
+RawPacket = NamedTuple('packet', (
     ('checksum', int),
     ('message_type', int),
     ('version', int),
@@ -23,7 +26,7 @@ RawPacket = typing.NamedTuple('packet', (
     ('payload_data', bytes),
 ))
 
-bits_format = {
+PACKET_FORMAT = {
     'checksum': 32,
     'message_type': 2,
     'version': 3,
@@ -38,11 +41,10 @@ bits_format = {
     'message_data_length': 16,
 }
 
-header_size = int(sum(bits_format.values()) / 8)
+HEADER_SIZE = int(sum(PACKET_FORMAT.values()) / 8)
 
 
-def _bits_as_int(bits: typing.Iterable[bool], length: int) -> int:
-
+def _bits_as_int(bits: Iterable[bool], length: int) -> int:
     value = ''
 
     for bit in itertools.islice(bits, length):
@@ -51,9 +53,7 @@ def _bits_as_int(bits: typing.Iterable[bool], length: int) -> int:
     return int(value, base=2)
 
 
-def _bytes_as_ints(data: bytes, offsets: typing.Iterable[int]) \
-        -> typing.Generator[int, None, None]:
-
+def _bytes_as_ints(data: bytes, offsets: Iterable[int]) -> Generator[int, None, None]:
     bits = bitarray.bitarray()
     bits.frombytes(data)
 
@@ -64,32 +64,25 @@ def _bytes_as_ints(data: bytes, offsets: typing.Iterable[int]) \
 
 
 def from_bytes(data: bytes) -> RawPacket:
+    if len(data) < HEADER_SIZE:
+        raise exceptions.PacketInvalidHeaderLengthError(len(data), HEADER_SIZE)
 
-    if len(data) < header_size:
-        raise ValueError(
-            f'Couldn\'t decode raw packet from bytes: '
-            f'invalid data length ({len(data)} < {header_size}).'
-        )
+    values = _bytes_as_ints(data[:HEADER_SIZE], PACKET_FORMAT.values())
 
-    values = _bytes_as_ints(data[:header_size], bits_format.values())
-
-    arguments: typing.Dict[str, typing.Any] = dict(zip(bits_format.keys(), values))
-
+    arguments: Dict[str, Any] = dict(zip(PACKET_FORMAT.keys(), values))
     arguments['nbit'] = bool(arguments['nbit'])
     arguments['cbit'] = bool(arguments['cbit'])
     arguments['sbit'] = bool(arguments['sbit'])
     arguments['dbit'] = bool(arguments['dbit'])
-    arguments['payload_data'] = data[header_size:]
+    arguments['payload_data'] = data[HEADER_SIZE:]
 
     return RawPacket(**arguments)
 
 
 def as_bytes(packet) -> bytes:
-
     bits = bitarray.bitarray()
 
-    for name, length in bits_format.items():
-
+    for name, length in PACKET_FORMAT.items():
         value = getattr(packet, name)
 
         for bit in f'{value:0{length}b}':

--- a/src/udpcp/protocol/exceptions.py
+++ b/src/udpcp/protocol/exceptions.py
@@ -1,0 +1,61 @@
+__all__ = [
+    'PacketError',
+    'PacketInvalidVersionError',
+    'PacketInvalidChecksumError',
+    'PacketInvalidMessageIdError',
+    'PacketInvalidFragmentAmountError',
+    'PacketInvalidFragmentNumberError',
+    'PacketAckBasePacketError',
+]
+
+from .. import protocol
+
+
+class PacketError(ValueError):
+    pass
+
+
+class PacketInvalidHeaderLengthError(PacketError):
+
+    def __init__(self, length: int, header_length: int):
+        super().__init__(f'Invalid packet header length {length} '
+                         f'(header length: {header_length})')
+
+
+class PacketInvalidVersionError(PacketError):
+
+    def __init__(self, version: int, protocol_version: int) -> None:
+        super().__init__(f'Invalid packet protocol version {version} '
+                         f'(protocol version: {protocol_version})')
+
+
+class PacketInvalidChecksumError(PacketError):
+
+    def __init__(self, checksum: int, packet_checksum: int):
+        super().__init__(f'Invalid packet checksum 0x{checksum:08x} '
+                         f'(packet checksum: 0x{packet_checksum:08x})')
+
+
+class PacketInvalidMessageIdError(PacketError):
+
+    def __init__(self, message_id: int):
+        super().__init__(f'Invalid packet message id 0x{message_id:04x}')
+
+
+class PacketInvalidFragmentAmountError(PacketError):
+
+    def __init__(self, amount: int):
+        super().__init__(f'Invalid packet fragment amount {amount}')
+
+
+class PacketInvalidFragmentNumberError(PacketError):
+
+    def __init__(self, amount: int, number: int):
+        super().__init__(f'Invalid packet fragment number {number} '
+                         f'(fragment amount: {amount}')
+
+
+class PacketAckBasePacketError(PacketError):
+
+    def __init__(self, packet: 'protocol.Packet'):
+        super().__init__(f'Invalid ack base packet {packet}')

--- a/src/udpcp/protocol/packet_type.py
+++ b/src/udpcp/protocol/packet_type.py
@@ -1,0 +1,13 @@
+__all__ = [
+    'PacketType',
+]
+
+import enum
+
+
+class PacketType(enum.Enum):
+
+    Ack = 'ack'
+    Sync = 'sync'
+    Data = 'data'
+    Invalid = 'invalid'

--- a/src/udpcp/socket.py
+++ b/src/udpcp/socket.py
@@ -1,0 +1,267 @@
+import math
+import queue
+import socket as native_socket
+import selectors
+import threading
+
+from typing import Dict, List, Tuple, Iterable, Optional
+from collections import defaultdict
+
+from .protocol import Packet, TransferMode, ChecksumMode
+
+from . import exceptions
+from .utils import Identifier, get_best_selector_class
+from .socket_fd import SocketFileDescriptor
+
+SocketAddress = Tuple[str, int]
+
+
+class Socket:
+
+    __slots__ = (
+        '_local_address',
+        '_transfer_mode',
+        '_checksum_mode',
+        '_retransmission_timeout',
+        '_retransmission_attempts',
+        '_maximum_connections',
+        '_socket',
+        '_thread',
+        '_identifiers',
+        '_outgoing_ack',
+        '_outgoing_packet',
+        '_incoming_data',
+        '_incoming_fragments',
+        '_shutdown_event',
+        '_shutdown_trigger',
+        '_file_descriptor',
+    )
+
+    MTU = 65536
+
+    def __init__(
+        self,
+        local_address: SocketAddress = ('0.0.0.0', 0),
+        transfer_mode: TransferMode = TransferMode.AckEveryPacket,
+        checksum_mode: ChecksumMode = ChecksumMode.Enabled,
+        *,
+        retransmission_timeout: int = 100,
+        retransmission_attempts: int = 5,
+        maximum_connections: int = 5
+    ):
+        self._local_address = local_address
+        self._transfer_mode = transfer_mode
+        self._checksum_mode = checksum_mode
+        self._retransmission_timeout = retransmission_timeout
+        self._retransmission_attempts = retransmission_attempts
+        self._maximum_connections = maximum_connections
+
+        self._socket: Optional[native_socket.socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self._identifiers: Dict[SocketAddress, Identifier] = defaultdict(Identifier)
+        self._outgoing_ack = threading.Event()
+        self._outgoing_packet: Optional[Tuple[Packet, SocketAddress]] = None
+        self._incoming_data: queue.Queue = queue.Queue()
+        self._incoming_fragments: Dict[SocketAddress, List[bytes]] = defaultdict(list)
+
+        self._shutdown_event = threading.Event()
+        self._shutdown_trigger = False
+        self._file_descriptor = SocketFileDescriptor()
+
+    def __enter__(self) -> 'Socket':
+        self.open()
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}[{self.local_address}]'
+
+    @staticmethod
+    def create_socket(reuse_address: bool = True, reuse_port: bool = True) -> native_socket.socket:
+        socket = native_socket.socket(native_socket.AF_INET, native_socket.SOCK_DGRAM)
+
+        socket.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEADDR, reuse_address)
+        socket.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEPORT, reuse_port)
+
+        return socket
+
+    @property
+    def is_opened(self) -> bool:
+        return True if self._socket is not None else False
+
+    @property
+    def is_closed(self) -> bool:
+        return not self.is_opened
+
+    @property
+    def local_address(self) -> SocketAddress:
+        return self._socket.getsockname() if self._socket else self._local_address
+
+    def fileno(self) -> int:
+        return self._file_descriptor.fileno()
+
+    def serve_forever(self, poll_interval: float = 0.5) -> None:
+        if self.is_closed:
+            raise exceptions.SocketClosedError()
+
+        self._shutdown_event.clear()
+
+        try:
+            self._serve_forever(poll_interval)
+        finally:
+            self._shutdown_trigger = False
+            self._shutdown_event.set()
+
+    def open(self) -> None:
+        self._socket = self.create_socket()
+
+        try:
+            self._socket.bind(self._local_address)
+        except native_socket.error as error:
+            try:
+                raise error
+            finally:
+                self.close()
+
+        self._thread = threading.Thread(target=self.serve_forever)
+        self._thread.start()
+
+    def close(self) -> None:
+        self.shutdown()
+
+        if self._socket:
+            self._socket.close()
+
+        if self._thread:
+            self._thread.join()
+
+        self._socket = None
+
+    def shutdown(self) -> None:
+        self._shutdown_trigger = True
+        self._shutdown_event.wait()
+
+    def send_to(self, data: bytes, address: SocketAddress) -> None:
+        if self.is_closed:
+            raise exceptions.SocketClosedError()
+
+        self._send_data(data, address)
+
+    def receive_from(self) -> Tuple[bytes, SocketAddress]:
+        try:
+            return self._incoming_data.get()
+        finally:
+            self._file_descriptor.notify_read()
+
+    def _serve_forever(self, poll_interval: float = 0.5) -> None:
+        if not self._socket:
+            raise exceptions.SocketError()
+
+        selector_class = get_best_selector_class()
+        selector = selector_class()
+        selector.register(self._socket, selectors.EVENT_READ)
+
+        while not self._shutdown_trigger:
+            if selector.select(poll_interval):
+                self._process_packet()
+
+    def _send_ack(self, data: Packet, address: SocketAddress, is_duplicate: bool = False) -> None:
+        ack = Packet.ack(data, is_duplicate=is_duplicate)
+
+        if not self._socket:
+            raise exceptions.SocketError()
+
+        self._socket.sendto(ack.as_bytes, address)
+
+    def _send_sync(self, address: SocketAddress) -> None:
+        sync = Packet.sync(self._checksum_mode)
+
+        if not self._socket:
+            raise exceptions.SocketError()
+
+        self._socket.sendto(sync.as_bytes, address)
+
+    def _send_data(self, data: bytes, address: SocketAddress) -> None:
+        message_id = self._identifiers[address].next()
+
+        for packet in self._fragment_into_packets(message_id, data):
+            for _ in range(self._retransmission_attempts):
+                try:
+                    self._send_data_packet(packet, address)
+                except TimeoutError:
+                    continue
+                else:
+                    break
+            else:
+                raise exceptions.SocketAckError()
+
+    def _send_data_packet(self, data: Packet, address: SocketAddress) -> None:
+        if data.is_ack_needed:
+            self._outgoing_packet = data, address
+
+        if not self._socket:
+            raise exceptions.SocketError()
+
+        self._socket.sendto(data.as_bytes, address)
+
+        if data.is_ack_needed:
+            self._outgoing_ack.wait(timeout=self._retransmission_timeout)
+            self._outgoing_ack.clear()
+            self._outgoing_packet = None
+
+    def _fragment_into_packets(self, message_id: int, data: bytes) -> Iterable[Packet]:
+        fragment_amount = int(math.ceil(len(data) / self.MTU))
+
+        for fragment_number in range(fragment_amount):
+            start = fragment_number * self.MTU
+            finish = (fragment_number + 1) * self.MTU
+
+            yield Packet.data(
+                transfer_mode=self._transfer_mode,
+                checksum_mode=self._checksum_mode,
+                fragment_amount=fragment_amount,
+                fragment_number=fragment_number,
+                message_id=message_id,
+                payload_data=data[start:finish],
+            )
+
+    def _process_packet(self) -> None:
+        if not self._socket:
+            raise exceptions.SocketError()
+
+        data, address = self._socket.recvfrom(self.MTU)
+        packet = Packet.from_bytes(data)
+
+        if packet.is_ack:
+            self._process_ack(packet, address)
+        elif packet.is_sync:
+            self._process_sync(packet, address)
+        elif packet.is_data:
+            self._process_data(packet, address)
+        else:
+            raise exceptions.SocketPacketError()
+
+    def _process_ack(self, ack: Packet, address: SocketAddress) -> None:
+        if self._outgoing_packet is None:
+            raise exceptions.SocketAckError()
+
+        data_packet, data_address = self._outgoing_packet
+
+        if ack.is_ack_for(data_packet) and address == data_address:
+            self._outgoing_ack.set()
+
+    def _process_sync(self, sync: Packet, address: SocketAddress) -> None:
+        self._send_ack(sync, address)
+
+    def _process_data(self, data: Packet, address: SocketAddress) -> None:
+        self._send_ack(data, address)
+        self._incoming_fragments[address].append(data.payload_data)
+
+        if len(self._incoming_fragments[address]) == data.fragment_amount:
+            try:
+                self._incoming_data.put((b''.join(self._incoming_fragments[address]), address))
+                self._file_descriptor.notify_write()
+            finally:
+                del self._incoming_fragments[address]

--- a/src/udpcp/socket_fd.py
+++ b/src/udpcp/socket_fd.py
@@ -1,0 +1,38 @@
+import os
+import threading
+
+
+class SocketFileDescriptor:
+
+    INPUT = b'W'
+
+    def __init__(self):
+        self._value = 0
+        self._condition = threading.Condition(threading.Lock())
+        self._read_fd, self._write_fd = os.pipe()
+
+    def __del__(self):
+        os.close(self._read_fd)
+        os.close(self._write_fd)
+
+    def fileno(self) -> int:
+        return self._read_fd
+
+    def notify_read(self) -> None:
+        with self._condition:
+            assert self._value > 0
+            self._value -= 1
+            self._set_event_read()
+
+    def notify_write(self) -> None:
+        with self._condition:
+            self._value += 1
+            self._set_event_write()
+
+    def _set_event_read(self) -> None:
+        if self._value == 0:
+            assert self.INPUT == os.read(self._read_fd, len(self.INPUT))
+
+    def _set_event_write(self) -> None:
+        if self._value == 1:
+            os.write(self._write_fd, self.INPUT)

--- a/src/udpcp/utils.py
+++ b/src/udpcp/utils.py
@@ -1,0 +1,26 @@
+__all__ = [
+    'Identifier',
+    'get_best_selector_class',
+]
+
+import itertools
+import selectors
+
+from typing import Type
+
+
+class Identifier:
+
+    def __init__(self):
+        self._generator = itertools.cycle(range(1, 0xFFFF))
+
+    def next(self) -> int:
+        return next(self._generator)
+
+
+def get_best_selector_class() -> Type[selectors.BaseSelector]:
+    for selector in ['EpollSelector', 'PollSelector', 'SelectSelector']:
+        if hasattr(selectors, selector):
+            return getattr(selectors, selector)
+
+    raise RuntimeError('Could not get any selector class')

--- a/tests/ut/test_packet.py
+++ b/tests/ut/test_packet.py
@@ -1,10 +1,9 @@
 import pytest
 
-from udpcp.protocol import Packet, MessageType, ChecksumMode, TransferMode
+from udpcp.protocol import Packet, PacketType, MessageType, ChecksumMode, TransferMode
 
 
 def test_ack():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -14,32 +13,26 @@ def test_ack():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert packet.is_ack
-    assert packet.type == 'ack'
+    assert packet.type == PacketType.Ack
 
     assert not packet.is_sync
     assert not packet.is_data
 
 
 def test_sync():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
+    packet = Packet.sync(ChecksumMode.Disabled)
 
     assert packet.is_sync
-    assert packet.type == 'sync'
+    assert packet.type == PacketType.Sync
 
     assert not packet.is_ack
     assert not packet.is_data
 
 
 def test_data():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -50,14 +43,13 @@ def test_data():
     )
 
     assert packet.is_data
-    assert packet.type == 'data'
+    assert packet.type == PacketType.Data
 
     assert not packet.is_ack
     assert not packet.is_sync
 
 
 def test_invalid():
-
     packet = Packet(
         message_type=MessageType.Ack,
         checksum_mode=ChecksumMode.Disabled,
@@ -70,7 +62,7 @@ def test_invalid():
         payload_data=b'dummy',
     )
 
-    assert packet.type == 'invalid'
+    assert packet.type == PacketType.Invalid
 
     assert not packet.is_ack
     assert not packet.is_sync
@@ -78,25 +70,18 @@ def test_invalid():
 
 
 def test_checksum_mode_enabled():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Enabled,
-    )
+    packet = Packet.sync(ChecksumMode.Enabled)
 
     assert packet.checksum == 0x2A20054
 
 
 def test_checksum_mode_disabled():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
+    packet = Packet.sync(ChecksumMode.Disabled)
 
     assert packet.checksum == 0
 
 
 def test_message_type_ack():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -106,24 +91,19 @@ def test_message_type_ack():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert packet.message_type is MessageType.Ack
+    assert packet.is_ack_for(data)
 
 
 def test_message_type_sync():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
+    packet = Packet.sync(ChecksumMode.Disabled)
 
     assert packet.message_type is MessageType.Data
 
 
 def test_message_type_data():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -137,7 +117,6 @@ def test_message_type_data():
 
 
 def test_transfer_mode_ack():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -147,26 +126,20 @@ def test_transfer_mode_ack():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert packet.transfer_mode is TransferMode.AckNone
     assert not packet.is_ack_needed
 
 
 def test_transfer_mode_sync():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
+    packet = Packet.sync(ChecksumMode.Disabled)
 
     assert packet.transfer_mode is TransferMode.AckEveryPacket
     assert packet.is_ack_needed
 
 
 def test_transfer_mode_data_every_packet():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -181,7 +154,6 @@ def test_transfer_mode_data_every_packet():
 
 
 def test_transfer_mode_data_last_fragment_only_when_ack_needed():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckLastFragmentOnly,
@@ -196,7 +168,6 @@ def test_transfer_mode_data_last_fragment_only_when_ack_needed():
 
 
 def test_transfer_mode_data_last_fragment_only_when_ack_not_needed():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckLastFragmentOnly,
@@ -211,7 +182,6 @@ def test_transfer_mode_data_last_fragment_only_when_ack_not_needed():
 
 
 def test_transfer_mode_data_none():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckNone,
@@ -226,7 +196,6 @@ def test_transfer_mode_data_none():
 
 
 def test_is_duplicate_ack_true():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -236,16 +205,12 @@ def test_is_duplicate_ack_true():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-        is_duplicate=True,
-    )
+    packet = Packet.ack(data, is_duplicate=True)
 
     assert packet.is_duplicate
 
 
 def test_is_duplicate_ack_false():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -255,24 +220,18 @@ def test_is_duplicate_ack_false():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert not packet.is_duplicate
 
 
 def test_is_duplicate_sync():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
+    packet = Packet.sync(ChecksumMode.Disabled)
 
     assert not packet.is_duplicate
 
 
 def test_is_duplicate_data():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -286,7 +245,6 @@ def test_is_duplicate_data():
 
 
 def test_fragment_ack_single():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -296,9 +254,7 @@ def test_fragment_ack_single():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert packet.fragment_amount == 1
     assert packet.fragment_number == 0
@@ -308,7 +264,6 @@ def test_fragment_ack_single():
 
 
 def test_fragment_ack_multiple():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -318,9 +273,7 @@ def test_fragment_ack_multiple():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert packet.fragment_amount == 10
     assert packet.fragment_number == 0
@@ -330,7 +283,6 @@ def test_fragment_ack_multiple():
 
 
 def test_fragment_ack_multiple_last():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -340,9 +292,7 @@ def test_fragment_ack_multiple_last():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert packet.fragment_amount == 10
     assert packet.fragment_number == 9
@@ -352,10 +302,7 @@ def test_fragment_ack_multiple_last():
 
 
 def test_fragment_sync():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
+    packet = Packet.sync(ChecksumMode.Disabled)
 
     assert packet.fragment_amount == 1
     assert packet.fragment_number == 0
@@ -365,7 +312,6 @@ def test_fragment_sync():
 
 
 def test_fragment_data_single():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -383,7 +329,6 @@ def test_fragment_data_single():
 
 
 def test_fragment_data_multiple():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -401,7 +346,6 @@ def test_fragment_data_multiple():
 
 
 def test_fragment_data_multiple_last():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -419,7 +363,6 @@ def test_fragment_data_multiple_last():
 
 
 def test_message_id_and_data_length_ack():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -429,26 +372,20 @@ def test_message_id_and_data_length_ack():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     assert packet.message_id == 12345
     assert packet.message_data_length == 0
 
 
 def test_message_id_and_data_length_sync():
-
-    packet = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
+    packet = Packet.sync(ChecksumMode.Disabled)
 
     assert packet.message_id == 0
     assert packet.message_data_length == 0
 
 
 def test_message_id_and_data_length_data():
-
     packet = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -463,7 +400,6 @@ def test_message_id_and_data_length_data():
 
 
 def test_invalid_ack():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -473,20 +409,14 @@ def test_invalid_ack():
         payload_data=b'dummy',
     )
 
-    packet = Packet.ack(
-        base_packet=data,
-    )
+    packet = Packet.ack(data)
 
     with pytest.raises(ValueError):
-        Packet.ack(
-            base_packet=packet,
-        )
+        Packet.ack(packet)
 
 
 def test_invalid_data():
-
     with pytest.raises(ValueError):
-
         Packet.data(
             checksum_mode=ChecksumMode.Disabled,
             transfer_mode=TransferMode.AckEveryPacket,
@@ -497,7 +427,6 @@ def test_invalid_data():
         )
 
     with pytest.raises(ValueError):
-
         Packet.data(
             checksum_mode=ChecksumMode.Disabled,
             transfer_mode=TransferMode.AckEveryPacket,
@@ -508,7 +437,6 @@ def test_invalid_data():
         )
 
     with pytest.raises(ValueError):
-
         Packet.data(
             checksum_mode=ChecksumMode.Disabled,
             transfer_mode=TransferMode.AckEveryPacket,
@@ -519,7 +447,6 @@ def test_invalid_data():
         )
 
     with pytest.raises(ValueError):
-
         Packet.data(
             checksum_mode=ChecksumMode.Disabled,
             transfer_mode=TransferMode.AckEveryPacket,
@@ -531,7 +458,6 @@ def test_invalid_data():
 
 
 def test_encode_decode_ack():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -541,10 +467,7 @@ def test_encode_decode_ack():
         payload_data=b'dummy',
     )
 
-    encoded = Packet.ack(
-        base_packet=data,
-    )
-
+    encoded = Packet.ack(data)
     encoded_bytes = bytes(encoded)
 
     decoded = Packet.from_bytes(encoded_bytes)
@@ -554,7 +477,6 @@ def test_encode_decode_ack():
 
 
 def test_encode_decode_ack_duplicate():
-
     data = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -564,11 +486,7 @@ def test_encode_decode_ack_duplicate():
         payload_data=b'dummy',
     )
 
-    encoded = Packet.ack(
-        base_packet=data,
-        is_duplicate=True,
-    )
-
+    encoded = Packet.ack(data, is_duplicate=True)
     encoded_bytes = bytes(encoded)
 
     decoded = Packet.from_bytes(encoded_bytes)
@@ -578,11 +496,7 @@ def test_encode_decode_ack_duplicate():
 
 
 def test_encode_decode_sync_checksum_mode_enabled():
-
-    encoded = Packet.sync(
-        checksum_mode=ChecksumMode.Enabled,
-    )
-
+    encoded = Packet.sync(ChecksumMode.Enabled)
     encoded_bytes = bytes(encoded)
 
     decoded = Packet.from_bytes(encoded_bytes)
@@ -592,11 +506,7 @@ def test_encode_decode_sync_checksum_mode_enabled():
 
 
 def test_encode_decode_sync_checksum_mode_disabled():
-
-    encoded = Packet.sync(
-        checksum_mode=ChecksumMode.Disabled,
-    )
-
+    encoded = Packet.sync(ChecksumMode.Disabled)
     encoded_bytes = bytes(encoded)
 
     decoded = Packet.from_bytes(encoded_bytes)
@@ -606,7 +516,6 @@ def test_encode_decode_sync_checksum_mode_disabled():
 
 
 def test_encode_decode_data():
-
     encoded = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckEveryPacket,
@@ -625,7 +534,6 @@ def test_encode_decode_data():
 
 
 def test_encode_decode_data_ack_last_fragment_only():
-
     encoded = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckLastFragmentOnly,
@@ -644,19 +552,16 @@ def test_encode_decode_data_ack_last_fragment_only():
 
 
 def test_decode_invalid_data_length():
-
     with pytest.raises(ValueError):
         Packet.from_bytes(b'dummy')
 
 
 def test_decode_invalid_packet_protocol_version():
-
     with pytest.raises(ValueError):
         Packet.from_bytes(b'000000000000')
 
 
 def test_decode_invalid_packet_checksum():
-
     encoded = Packet.data(
         checksum_mode=ChecksumMode.Disabled,
         transfer_mode=TransferMode.AckLastFragmentOnly,


### PR DESCRIPTION
First version of Socket class was added together with changes in lint
to keep code closer to PEP8 style. Also PacketType enum was added for
readability and custom exceptions were introduced for both Packet and
Socket.